### PR TITLE
Fix random download error on large courses

### DIFF
--- a/index.js
+++ b/index.js
@@ -178,10 +178,9 @@ async function scrapeSite(course_url) {
             count++;
             console.log(`Download ${count}/${totalVideos} Started`);
         }
+        // Wait for all downloads in the unit to complete
+        await Promise.all(downloadPromises);
     }
-
-    // Wait for all downloads to complete
-    await Promise.all(downloadPromises);
 
     await page.close();
     await browser.close();


### PR DESCRIPTION
On large courses (> 50 videos) I'm getting random errors due to downloads timeouts. This change downloads one unit at a time to reduce the chance of failed downloads.